### PR TITLE
CDMS-1095: Refactor repository code to centralise key logic in specific functions and reduce repetition

### DIFF
--- a/src/Api/Data/ReportRepository.cs
+++ b/src/Api/Data/ReportRepository.cs
@@ -4,6 +4,8 @@ using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Conventions;
 using MongoDB.Driver;
 
+// ReSharper disable InconsistentNaming
+
 namespace Defra.TradeImportsReportingApi.Api.Data;
 
 [ExcludeFromCodeCoverage]
@@ -103,6 +105,10 @@ public class ReportRepository(IDbContext dbContext) : IReportRepository
     {
         GuardUtc(from, to);
 
+        const string automatic = nameof(automatic);
+        const string manual = nameof(manual);
+        const string total = nameof(total);
+
         var pipeline = new[]
         {
             ReleasesMatch(from, to),
@@ -135,51 +141,9 @@ public class ReportRepository(IDbContext dbContext) : IReportRepository
                 new BsonDocument
                 {
                     { "_id", 1 },
-                    {
-                        "automatic",
-                        new BsonDocument(
-                            "$sum",
-                            new BsonDocument(
-                                "$cond",
-                                new BsonArray
-                                {
-                                    new BsonDocument(
-                                        "$eq",
-                                        new BsonArray
-                                        {
-                                            $"$latest.{Fields.Finalisation.ReleaseType}",
-                                            ReleaseType.Automatic,
-                                        }
-                                    ),
-                                    1,
-                                    0,
-                                }
-                            )
-                        )
-                    },
-                    {
-                        "manual",
-                        new BsonDocument(
-                            "$sum",
-                            new BsonDocument(
-                                "$cond",
-                                new BsonArray
-                                {
-                                    new BsonDocument(
-                                        "$eq",
-                                        new BsonArray
-                                        {
-                                            $"$latest.{Fields.Finalisation.ReleaseType}",
-                                            ReleaseType.Manual,
-                                        }
-                                    ),
-                                    1,
-                                    0,
-                                }
-                            )
-                        )
-                    },
-                    { "total", new BsonDocument("$sum", 1) },
+                    FieldSum(automatic, Fields.Finalisation.ReleaseType, ReleaseType.Automatic),
+                    FieldSum(manual, Fields.Finalisation.ReleaseType, ReleaseType.Manual),
+                    { total, new BsonDocument("$sum", 1) },
                 }
             ),
             new BsonDocument(
@@ -187,9 +151,9 @@ public class ReportRepository(IDbContext dbContext) : IReportRepository
                 new BsonDocument
                 {
                     { "_id", 0 },
-                    { "automatic", 1 },
-                    { "manual", 1 },
-                    { "total", 1 },
+                    { automatic, 1 },
+                    { manual, 1 },
+                    { total, 1 },
                 }
             ),
         };
@@ -213,6 +177,10 @@ public class ReportRepository(IDbContext dbContext) : IReportRepository
     {
         GuardUtc(from, to);
         GuardUnit(unit);
+
+        const string automatic = nameof(automatic);
+        const string manual = nameof(manual);
+        const string total = nameof(total);
 
         var pipeline = new[]
         {
@@ -274,51 +242,9 @@ public class ReportRepository(IDbContext dbContext) : IReportRepository
                         "_id",
                         new BsonDocument { { "bucket", "$_id.bucket" } }
                     },
-                    {
-                        "automatic",
-                        new BsonDocument(
-                            "$sum",
-                            new BsonDocument(
-                                "$cond",
-                                new BsonArray
-                                {
-                                    new BsonDocument(
-                                        "$eq",
-                                        new BsonArray
-                                        {
-                                            $"$latest.{Fields.Finalisation.ReleaseType}",
-                                            ReleaseType.Automatic,
-                                        }
-                                    ),
-                                    1,
-                                    0,
-                                }
-                            )
-                        )
-                    },
-                    {
-                        "manual",
-                        new BsonDocument(
-                            "$sum",
-                            new BsonDocument(
-                                "$cond",
-                                new BsonArray
-                                {
-                                    new BsonDocument(
-                                        "$eq",
-                                        new BsonArray
-                                        {
-                                            $"$latest.{Fields.Finalisation.ReleaseType}",
-                                            ReleaseType.Manual,
-                                        }
-                                    ),
-                                    1,
-                                    0,
-                                }
-                            )
-                        )
-                    },
-                    { "total", new BsonDocument("$sum", 1) },
+                    FieldSum(automatic, Fields.Finalisation.ReleaseType, ReleaseType.Automatic),
+                    FieldSum(manual, Fields.Finalisation.ReleaseType, ReleaseType.Manual),
+                    { total, new BsonDocument("$sum", 1) },
                 }
             ),
             new BsonDocument(
@@ -331,9 +257,9 @@ public class ReportRepository(IDbContext dbContext) : IReportRepository
                         "summary",
                         new BsonDocument
                         {
-                            { "automatic", "$automatic" },
-                            { "manual", "$manual" },
-                            { "total", "$total" },
+                            { automatic, $"${automatic}" },
+                            { manual, $"${manual}" },
+                            { total, $"${total}" },
                         }
                     },
                 }
@@ -389,6 +315,10 @@ public class ReportRepository(IDbContext dbContext) : IReportRepository
     {
         GuardUtc(from, to);
 
+        const string match = nameof(match);
+        const string noMatch = nameof(noMatch);
+        const string total = nameof(total);
+
         var pipeline = new[]
         {
             MatchesMatch(from, to),
@@ -415,40 +345,9 @@ public class ReportRepository(IDbContext dbContext) : IReportRepository
                 new BsonDocument
                 {
                     { "_id", 1 },
-                    {
-                        "match",
-                        new BsonDocument(
-                            "$sum",
-                            new BsonDocument(
-                                "$cond",
-                                new BsonArray
-                                {
-                                    new BsonDocument("$eq", new BsonArray { $"$latest.{Fields.Decision.Match}", true }),
-                                    1,
-                                    0,
-                                }
-                            )
-                        )
-                    },
-                    {
-                        "noMatch",
-                        new BsonDocument(
-                            "$sum",
-                            new BsonDocument(
-                                "$cond",
-                                new BsonArray
-                                {
-                                    new BsonDocument(
-                                        "$eq",
-                                        new BsonArray { $"$latest.{Fields.Decision.Match}", false }
-                                    ),
-                                    1,
-                                    0,
-                                }
-                            )
-                        )
-                    },
-                    { "total", new BsonDocument("$sum", 1) },
+                    FieldSum(match, Fields.Decision.Match, true),
+                    FieldSum(noMatch, Fields.Decision.Match, false),
+                    { total, new BsonDocument("$sum", 1) },
                 }
             ),
             new BsonDocument(
@@ -456,9 +355,9 @@ public class ReportRepository(IDbContext dbContext) : IReportRepository
                 new BsonDocument
                 {
                     { "_id", 0 },
-                    { "match", 1 },
-                    { "noMatch", 1 },
-                    { "total", 1 },
+                    { match, 1 },
+                    { noMatch, 1 },
+                    { total, 1 },
                 }
             ),
         };
@@ -482,6 +381,10 @@ public class ReportRepository(IDbContext dbContext) : IReportRepository
     {
         GuardUtc(from, to);
         GuardUnit(unit);
+
+        const string match = nameof(match);
+        const string noMatch = nameof(noMatch);
+        const string total = nameof(total);
 
         var pipeline = new[]
         {
@@ -533,40 +436,9 @@ public class ReportRepository(IDbContext dbContext) : IReportRepository
                         "_id",
                         new BsonDocument { { "bucket", "$_id.bucket" } }
                     },
-                    {
-                        "match",
-                        new BsonDocument(
-                            "$sum",
-                            new BsonDocument(
-                                "$cond",
-                                new BsonArray
-                                {
-                                    new BsonDocument("$eq", new BsonArray { $"$latest.{Fields.Decision.Match}", true }),
-                                    1,
-                                    0,
-                                }
-                            )
-                        )
-                    },
-                    {
-                        "noMatch",
-                        new BsonDocument(
-                            "$sum",
-                            new BsonDocument(
-                                "$cond",
-                                new BsonArray
-                                {
-                                    new BsonDocument(
-                                        "$eq",
-                                        new BsonArray { $"$latest.{Fields.Decision.Match}", false }
-                                    ),
-                                    1,
-                                    0,
-                                }
-                            )
-                        )
-                    },
-                    { "total", new BsonDocument("$sum", 1) },
+                    FieldSum(match, Fields.Decision.Match, true),
+                    FieldSum(noMatch, Fields.Decision.Match, false),
+                    { total, new BsonDocument("$sum", 1) },
                 }
             ),
             new BsonDocument(
@@ -579,9 +451,9 @@ public class ReportRepository(IDbContext dbContext) : IReportRepository
                         "summary",
                         new BsonDocument
                         {
-                            { "match", "$match" },
-                            { "noMatch", "$noMatch" },
-                            { "total", "$total" },
+                            { match, $"${match}" },
+                            { noMatch, $"${noMatch}" },
+                            { total, $"${total}" },
                         }
                     },
                 }
@@ -773,6 +645,12 @@ public class ReportRepository(IDbContext dbContext) : IReportRepository
     {
         GuardUtc(from, to);
 
+        const string chedA = nameof(chedA);
+        const string chedP = nameof(chedP);
+        const string chedPP = nameof(chedPP);
+        const string chedD = nameof(chedD);
+        const string total = nameof(total);
+
         var pipeline = new[]
         {
             NotificationsMatch(from, to),
@@ -805,95 +683,11 @@ public class ReportRepository(IDbContext dbContext) : IReportRepository
                 new BsonDocument
                 {
                     { "_id", 1 },
-                    {
-                        "chedA",
-                        new BsonDocument(
-                            "$sum",
-                            new BsonDocument(
-                                "$cond",
-                                new BsonArray
-                                {
-                                    new BsonDocument(
-                                        "$eq",
-                                        new BsonArray
-                                        {
-                                            $"$latest.{Fields.Notification.NotificationType}",
-                                            NotificationType.ChedA,
-                                        }
-                                    ),
-                                    1,
-                                    0,
-                                }
-                            )
-                        )
-                    },
-                    {
-                        "chedP",
-                        new BsonDocument(
-                            "$sum",
-                            new BsonDocument(
-                                "$cond",
-                                new BsonArray
-                                {
-                                    new BsonDocument(
-                                        "$eq",
-                                        new BsonArray
-                                        {
-                                            $"$latest.{Fields.Notification.NotificationType}",
-                                            NotificationType.ChedP,
-                                        }
-                                    ),
-                                    1,
-                                    0,
-                                }
-                            )
-                        )
-                    },
-                    {
-                        "chedPP",
-                        new BsonDocument(
-                            "$sum",
-                            new BsonDocument(
-                                "$cond",
-                                new BsonArray
-                                {
-                                    new BsonDocument(
-                                        "$eq",
-                                        new BsonArray
-                                        {
-                                            $"$latest.{Fields.Notification.NotificationType}",
-                                            NotificationType.ChedPP,
-                                        }
-                                    ),
-                                    1,
-                                    0,
-                                }
-                            )
-                        )
-                    },
-                    {
-                        "chedD",
-                        new BsonDocument(
-                            "$sum",
-                            new BsonDocument(
-                                "$cond",
-                                new BsonArray
-                                {
-                                    new BsonDocument(
-                                        "$eq",
-                                        new BsonArray
-                                        {
-                                            $"$latest.{Fields.Notification.NotificationType}",
-                                            NotificationType.ChedD,
-                                        }
-                                    ),
-                                    1,
-                                    0,
-                                }
-                            )
-                        )
-                    },
-                    { "total", new BsonDocument("$sum", 1) },
+                    FieldSum(chedA, Fields.Notification.NotificationType, NotificationType.ChedA),
+                    FieldSum(chedP, Fields.Notification.NotificationType, NotificationType.ChedP),
+                    FieldSum(chedPP, Fields.Notification.NotificationType, NotificationType.ChedPP),
+                    FieldSum(chedD, Fields.Notification.NotificationType, NotificationType.ChedD),
+                    { total, new BsonDocument("$sum", 1) },
                 }
             ),
             new BsonDocument(
@@ -901,11 +695,11 @@ public class ReportRepository(IDbContext dbContext) : IReportRepository
                 new BsonDocument
                 {
                     { "_id", 0 },
-                    { "chedA", 1 },
-                    { "chedP", 1 },
-                    { "chedPP", 1 },
-                    { "chedD", 1 },
-                    { "total", 1 },
+                    { chedA, 1 },
+                    { chedP, 1 },
+                    { chedPP, 1 },
+                    { chedD, 1 },
+                    { total, 1 },
                 }
             ),
         };
@@ -929,6 +723,12 @@ public class ReportRepository(IDbContext dbContext) : IReportRepository
     {
         GuardUtc(from, to);
         GuardUnit(unit);
+
+        const string chedA = nameof(chedA);
+        const string chedP = nameof(chedP);
+        const string chedPP = nameof(chedPP);
+        const string chedD = nameof(chedD);
+        const string total = nameof(total);
 
         var pipeline = new[]
         {
@@ -990,95 +790,11 @@ public class ReportRepository(IDbContext dbContext) : IReportRepository
                         "_id",
                         new BsonDocument { { "bucket", "$_id.bucket" } }
                     },
-                    {
-                        "chedA",
-                        new BsonDocument(
-                            "$sum",
-                            new BsonDocument(
-                                "$cond",
-                                new BsonArray
-                                {
-                                    new BsonDocument(
-                                        "$eq",
-                                        new BsonArray
-                                        {
-                                            $"$latest.{Fields.Notification.NotificationType}",
-                                            NotificationType.ChedA,
-                                        }
-                                    ),
-                                    1,
-                                    0,
-                                }
-                            )
-                        )
-                    },
-                    {
-                        "chedP",
-                        new BsonDocument(
-                            "$sum",
-                            new BsonDocument(
-                                "$cond",
-                                new BsonArray
-                                {
-                                    new BsonDocument(
-                                        "$eq",
-                                        new BsonArray
-                                        {
-                                            $"$latest.{Fields.Notification.NotificationType}",
-                                            NotificationType.ChedP,
-                                        }
-                                    ),
-                                    1,
-                                    0,
-                                }
-                            )
-                        )
-                    },
-                    {
-                        "chedPP",
-                        new BsonDocument(
-                            "$sum",
-                            new BsonDocument(
-                                "$cond",
-                                new BsonArray
-                                {
-                                    new BsonDocument(
-                                        "$eq",
-                                        new BsonArray
-                                        {
-                                            $"$latest.{Fields.Notification.NotificationType}",
-                                            NotificationType.ChedPP,
-                                        }
-                                    ),
-                                    1,
-                                    0,
-                                }
-                            )
-                        )
-                    },
-                    {
-                        "chedD",
-                        new BsonDocument(
-                            "$sum",
-                            new BsonDocument(
-                                "$cond",
-                                new BsonArray
-                                {
-                                    new BsonDocument(
-                                        "$eq",
-                                        new BsonArray
-                                        {
-                                            $"$latest.{Fields.Notification.NotificationType}",
-                                            NotificationType.ChedD,
-                                        }
-                                    ),
-                                    1,
-                                    0,
-                                }
-                            )
-                        )
-                    },
-                    { "total", new BsonDocument("$sum", 1) },
+                    FieldSum(chedA, Fields.Notification.NotificationType, NotificationType.ChedA),
+                    FieldSum(chedP, Fields.Notification.NotificationType, NotificationType.ChedP),
+                    FieldSum(chedPP, Fields.Notification.NotificationType, NotificationType.ChedPP),
+                    FieldSum(chedD, Fields.Notification.NotificationType, NotificationType.ChedD),
+                    { total, new BsonDocument("$sum", 1) },
                 }
             ),
             new BsonDocument(
@@ -1091,11 +807,11 @@ public class ReportRepository(IDbContext dbContext) : IReportRepository
                         "summary",
                         new BsonDocument
                         {
-                            { "chedA", "$chedA" },
-                            { "chedP", "$chedP" },
-                            { "chedPP", "$chedPP" },
-                            { "chedD", "$chedD" },
-                            { "total", "$total" },
+                            { chedA, $"${chedA}" },
+                            { chedP, $"${chedP}" },
+                            { chedPP, $"${chedPP}" },
+                            { chedD, $"${chedD}" },
+                            { total, $"${total}" },
                         }
                     },
                 }
@@ -1192,4 +908,18 @@ public class ReportRepository(IDbContext dbContext) : IReportRepository
 
     private static BsonDocument FromAndToMatch(string field, DateTime from, DateTime to) =>
         new(field, new BsonDocument { { "$gte", from }, { "$lt", to } });
+
+    private static BsonElement FieldSum(string name, string field, BsonValue value)
+    {
+        return new BsonElement(
+            name,
+            new BsonDocument(
+                "$sum",
+                new BsonDocument(
+                    "$cond",
+                    new BsonArray { new BsonDocument("$eq", new BsonArray { $"$latest.{field}", value }), 1, 0 }
+                )
+            )
+        );
+    }
 }

--- a/src/Api/Data/ReportRepository.cs
+++ b/src/Api/Data/ReportRepository.cs
@@ -117,23 +117,7 @@ public class ReportRepository(IDbContext dbContext) : IReportRepository
                 new BsonDocument
                 {
                     { "_id", $"${Fields.Finalisation.Mrn}" },
-                    {
-                        "latest",
-                        new BsonDocument(
-                            "$top",
-                            new BsonDocument
-                            {
-                                { "sortBy", new BsonDocument(Fields.Finalisation.Timestamp, -1) },
-                                {
-                                    "output",
-                                    new BsonDocument(
-                                        Fields.Finalisation.ReleaseType,
-                                        $"${Fields.Finalisation.ReleaseType}"
-                                    )
-                                },
-                            }
-                        )
-                    },
+                    SortAndTakeLatest(Fields.Finalisation.Timestamp, Fields.Finalisation.ReleaseType),
                 }
             ),
             new BsonDocument(
@@ -215,23 +199,7 @@ public class ReportRepository(IDbContext dbContext) : IReportRepository
                             { Fields.Finalisation.Mrn, $"${Fields.Finalisation.Mrn}" },
                         }
                     },
-                    {
-                        "latest",
-                        new BsonDocument(
-                            "$top",
-                            new BsonDocument
-                            {
-                                { "sortBy", new BsonDocument(Fields.Finalisation.Timestamp, -1) },
-                                {
-                                    "output",
-                                    new BsonDocument(
-                                        Fields.Finalisation.ReleaseType,
-                                        $"${Fields.Finalisation.ReleaseType}"
-                                    )
-                                },
-                            }
-                        )
-                    },
+                    SortAndTakeLatest(Fields.Finalisation.Timestamp, Fields.Finalisation.ReleaseType),
                 }
             ),
             new BsonDocument(
@@ -327,17 +295,7 @@ public class ReportRepository(IDbContext dbContext) : IReportRepository
                 new BsonDocument
                 {
                     { "_id", $"${Fields.Decision.Mrn}" },
-                    {
-                        "latest",
-                        new BsonDocument(
-                            "$top",
-                            new BsonDocument
-                            {
-                                { "sortBy", new BsonDocument(Fields.Decision.Timestamp, -1) },
-                                { "output", new BsonDocument(Fields.Decision.Match, $"${Fields.Decision.Match}") },
-                            }
-                        )
-                    },
+                    SortAndTakeLatest(Fields.Decision.Timestamp, Fields.Decision.Match),
                 }
             ),
             new BsonDocument(
@@ -415,17 +373,7 @@ public class ReportRepository(IDbContext dbContext) : IReportRepository
                         "_id",
                         new BsonDocument { { "bucket", "$bucket" }, { Fields.Decision.Mrn, $"${Fields.Decision.Mrn}" } }
                     },
-                    {
-                        "latest",
-                        new BsonDocument(
-                            "$top",
-                            new BsonDocument
-                            {
-                                { "sortBy", new BsonDocument(Fields.Decision.Timestamp, -1) },
-                                { "output", new BsonDocument(Fields.Decision.Match, $"${Fields.Decision.Match}") },
-                            }
-                        )
-                    },
+                    SortAndTakeLatest(Fields.Decision.Timestamp, Fields.Decision.Match),
                 }
             ),
             new BsonDocument(
@@ -560,17 +508,7 @@ public class ReportRepository(IDbContext dbContext) : IReportRepository
                 new BsonDocument
                 {
                     { "_id", $"${Fields.Request.Mrn}" },
-                    {
-                        "latest",
-                        new BsonDocument(
-                            "$top",
-                            new BsonDocument
-                            {
-                                { "sortBy", new BsonDocument(Fields.Request.Timestamp, -1) },
-                                { "output", new BsonDocument("ts", $"${Fields.Request.Timestamp}") },
-                            }
-                        )
-                    },
+                    SortAndTakeLatest(Fields.Request.Timestamp, Fields.Request.Timestamp),
                 }
             ),
             new BsonDocument(
@@ -583,7 +521,7 @@ public class ReportRepository(IDbContext dbContext) : IReportRepository
                             "$dateTrunc",
                             new BsonDocument
                             {
-                                { "date", "$latest.ts" },
+                                { "date", $"$latest.{Fields.Request.Timestamp}" },
                                 { "unit", unit },
                                 { "timezone", "UTC" },
                             }
@@ -659,23 +597,7 @@ public class ReportRepository(IDbContext dbContext) : IReportRepository
                 new BsonDocument
                 {
                     { "_id", $"${Fields.Notification.ReferenceNumber}" },
-                    {
-                        "latest",
-                        new BsonDocument(
-                            "$top",
-                            new BsonDocument
-                            {
-                                { "sortBy", new BsonDocument(Fields.Notification.Timestamp, -1) },
-                                {
-                                    "output",
-                                    new BsonDocument(
-                                        Fields.Notification.NotificationType,
-                                        $"${Fields.Notification.NotificationType}"
-                                    )
-                                },
-                            }
-                        )
-                    },
+                    SortAndTakeLatest(Fields.Notification.Timestamp, Fields.Notification.NotificationType),
                 }
             ),
             new BsonDocument(
@@ -763,23 +685,7 @@ public class ReportRepository(IDbContext dbContext) : IReportRepository
                             { Fields.Notification.ReferenceNumber, $"${Fields.Notification.ReferenceNumber}" },
                         }
                     },
-                    {
-                        "latest",
-                        new BsonDocument(
-                            "$top",
-                            new BsonDocument
-                            {
-                                { "sortBy", new BsonDocument(Fields.Notification.Timestamp, -1) },
-                                {
-                                    "output",
-                                    new BsonDocument(
-                                        Fields.Notification.NotificationType,
-                                        $"${Fields.Notification.NotificationType}"
-                                    )
-                                },
-                            }
-                        )
-                    },
+                    SortAndTakeLatest(Fields.Notification.Timestamp, Fields.Notification.NotificationType),
                 }
             ),
             new BsonDocument(
@@ -919,6 +825,21 @@ public class ReportRepository(IDbContext dbContext) : IReportRepository
                     "$cond",
                     new BsonArray { new BsonDocument("$eq", new BsonArray { $"$latest.{field}", value }), 1, 0 }
                 )
+            )
+        );
+    }
+
+    private static BsonElement SortAndTakeLatest(string sortByField, string returnField)
+    {
+        return new BsonElement(
+            "latest",
+            new BsonDocument(
+                "$top",
+                new BsonDocument
+                {
+                    { "sortBy", new BsonDocument(sortByField, -1) },
+                    { "output", new BsonDocument(returnField, $"${returnField}") },
+                }
             )
         );
     }

--- a/src/Api/Data/ReportRepository.cs
+++ b/src/Api/Data/ReportRepository.cs
@@ -169,24 +169,7 @@ public class ReportRepository(IDbContext dbContext) : IReportRepository
         var pipeline = new[]
         {
             ReleasesMatch(from, to),
-            new BsonDocument(
-                "$set",
-                new BsonDocument
-                {
-                    {
-                        "bucket",
-                        new BsonDocument(
-                            "$dateTrunc",
-                            new BsonDocument
-                            {
-                                { "date", $"${Fields.Finalisation.Timestamp}" },
-                                { "unit", unit },
-                                { "timezone", "UTC" },
-                            }
-                        )
-                    },
-                }
-            ),
+            new BsonDocument("$set", Bucket(Fields.Finalisation.Timestamp, unit)),
             new BsonDocument(
                 "$group",
                 new BsonDocument
@@ -347,24 +330,7 @@ public class ReportRepository(IDbContext dbContext) : IReportRepository
         var pipeline = new[]
         {
             MatchesMatch(from, to),
-            new BsonDocument(
-                "$set",
-                new BsonDocument
-                {
-                    {
-                        "bucket",
-                        new BsonDocument(
-                            "$dateTrunc",
-                            new BsonDocument
-                            {
-                                { "date", $"${Fields.Decision.MrnCreated}" },
-                                { "unit", unit },
-                                { "timezone", "UTC" },
-                            }
-                        )
-                    },
-                }
-            ),
+            new BsonDocument("$set", Bucket(Fields.Decision.MrnCreated, unit)),
             new BsonDocument(
                 "$group",
                 new BsonDocument
@@ -511,24 +477,7 @@ public class ReportRepository(IDbContext dbContext) : IReportRepository
                     SortAndTakeLatest(Fields.Request.Timestamp, Fields.Request.Timestamp),
                 }
             ),
-            new BsonDocument(
-                "$set",
-                new BsonDocument
-                {
-                    {
-                        "bucket",
-                        new BsonDocument(
-                            "$dateTrunc",
-                            new BsonDocument
-                            {
-                                { "date", $"$latest.{Fields.Request.Timestamp}" },
-                                { "unit", unit },
-                                { "timezone", "UTC" },
-                            }
-                        )
-                    },
-                }
-            ),
+            new BsonDocument("$set", Bucket(Fields.Request.Timestamp, unit, fieldPrefix: "latest.")),
             new BsonDocument(
                 "$group",
                 new BsonDocument
@@ -655,24 +604,7 @@ public class ReportRepository(IDbContext dbContext) : IReportRepository
         var pipeline = new[]
         {
             NotificationsMatch(from, to),
-            new BsonDocument(
-                "$set",
-                new BsonDocument
-                {
-                    {
-                        "bucket",
-                        new BsonDocument(
-                            "$dateTrunc",
-                            new BsonDocument
-                            {
-                                { "date", $"${Fields.Notification.NotificationCreated}" },
-                                { "unit", unit },
-                                { "timezone", "UTC" },
-                            }
-                        )
-                    },
-                }
-            ),
+            new BsonDocument("$set", Bucket(Fields.Notification.NotificationCreated, unit)),
             new BsonDocument(
                 "$group",
                 new BsonDocument
@@ -842,5 +774,24 @@ public class ReportRepository(IDbContext dbContext) : IReportRepository
                 }
             )
         );
+    }
+
+    private static BsonDocument Bucket(string field, string unit, string? fieldPrefix = null)
+    {
+        return new BsonDocument
+        {
+            {
+                "bucket",
+                new BsonDocument(
+                    "$dateTrunc",
+                    new BsonDocument
+                    {
+                        { "date", $"${fieldPrefix}{field}" },
+                        { "unit", unit },
+                        { "timezone", "UTC" },
+                    }
+                )
+            },
+        };
     }
 }

--- a/src/Api/Data/ReportRepository.cs
+++ b/src/Api/Data/ReportRepository.cs
@@ -1170,13 +1170,7 @@ public class ReportRepository(IDbContext dbContext) : IReportRepository
 
     private static BsonDocument ReleasesMatch(DateTime from, DateTime to, bool restrictReleaseType = true)
     {
-        var match = new BsonDocument
-        {
-            {
-                Fields.Finalisation.Timestamp,
-                new BsonDocument { { "$gte", from }, { "$lt", to } }
-            },
-        };
+        var match = FromAndToMatch(Fields.Finalisation.Timestamp, from, to);
 
         if (restrictReleaseType)
             match.Add(
@@ -1187,30 +1181,15 @@ public class ReportRepository(IDbContext dbContext) : IReportRepository
         return new BsonDocument("$match", match);
     }
 
-    private static BsonDocument MatchesMatch(DateTime from, DateTime to)
-    {
-        return new BsonDocument(
-            "$match",
-            new BsonDocument(Fields.Decision.MrnCreated, new BsonDocument { { "$gte", from }, { "$lt", to } })
-        );
-    }
+    private static BsonDocument MatchesMatch(DateTime from, DateTime to) =>
+        new("$match", FromAndToMatch(Fields.Decision.MrnCreated, from, to));
 
-    private static BsonDocument ClearanceRequestMatch(DateTime from, DateTime to)
-    {
-        return new BsonDocument(
-            "$match",
-            new BsonDocument(Fields.Request.Timestamp, new BsonDocument { { "$gte", from }, { "$lt", to } })
-        );
-    }
+    private static BsonDocument ClearanceRequestMatch(DateTime from, DateTime to) =>
+        new("$match", FromAndToMatch(Fields.Request.Timestamp, from, to));
 
-    private static BsonDocument NotificationsMatch(DateTime from, DateTime to)
-    {
-        return new BsonDocument(
-            "$match",
-            new BsonDocument(
-                Fields.Notification.NotificationCreated,
-                new BsonDocument { { "$gte", from }, { "$lt", to } }
-            )
-        );
-    }
+    private static BsonDocument NotificationsMatch(DateTime from, DateTime to) =>
+        new("$match", FromAndToMatch(Fields.Notification.NotificationCreated, from, to));
+
+    private static BsonDocument FromAndToMatch(string field, DateTime from, DateTime to) =>
+        new(field, new BsonDocument { { "$gte", from }, { "$lt", to } });
 }


### PR DESCRIPTION
This PR can be reviewed commit by commit in order to observe the refactoring progression.

Aim is to reduce overall code by replacing repeated sections into specific functions, which will hopefully guard against ongoing change if it's needed.

The key methods for each data type are things like filtering, bucketing by time, and gathering totals for either summary or bucket results.

There is no operational/behaviour change with this PR, it's just code refactoring to try and improve clarity for the future.