### PR TITLE
Fix: Override vulnerable SharpCompress transitive dependency

### DIFF
--- a/src/Api/Api.csproj
+++ b/src/Api/Api.csproj
@@ -42,6 +42,8 @@
     <PackageReference Include="AWSSDK.Core" Version="4.0.6.1" />
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.3.37" />
     <PackageReference Include="AWSSDK.SQS" Version="4.0.2.28" />
+    <!-- Override vulnerable transitive dependency SharpCompress -->
+    <PackageReference Include="SharpCompress" Version="0.48.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Update="SonarAnalyzer.CSharp" Version="10.21.0.135717" />

--- a/tests/Api.IntegrationTests/Api.IntegrationTests.csproj
+++ b/tests/Api.IntegrationTests/Api.IntegrationTests.csproj
@@ -7,6 +7,7 @@
     <RootNamespace>Defra.TradeImportsReportingApi.Api.IntegrationTests</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="SharpCompress" Version="0.48.0" />
     <PackageReference Include="Snappier" Version="1.3.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />

--- a/tests/Api.Tests/Api.Tests.csproj
+++ b/tests/Api.Tests/Api.Tests.csproj
@@ -12,6 +12,7 @@
     <Using Include="FluentAssertions" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="SharpCompress" Version="0.48.0" />
     <PackageReference Include="Snappier" Version="1.3.1" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.5.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />

--- a/tests/TestFixtures/TestFixtures.csproj
+++ b/tests/TestFixtures/TestFixtures.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
+    <PackageReference Include="SharpCompress" Version="0.48.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Update="SonarAnalyzer.CSharp" Version="10.21.0.135717" />

--- a/tests/Testing/Testing.csproj
+++ b/tests/Testing/Testing.csproj
@@ -7,6 +7,7 @@
     <RootNamespace>Defra.TradeImportsReportingApi.Testing</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="SharpCompress" Version="0.48.0" />
     <PackageReference Include="Snappier" Version="1.3.1" />
     <PackageReference Include="AutoFixture.Xunit2" Version="4.18.1" />
     <PackageReference Include="FluentAssertions" Version="8.9.0" />


### PR DESCRIPTION
Explicitly adds a direct package reference to SharpCompress version 0.48.0 across all projects to mitigate a security vulnerability in a transitive dependency.
