### PR TITLE
CDMS-1342: Add DeclarantId and DispatchCountryCode to customs declarations

### DIFF
--- a/src/Api/Data/Entities/CustomsDeclaration.cs
+++ b/src/Api/Data/Entities/CustomsDeclaration.cs
@@ -14,6 +14,8 @@ public class CustomsDeclaration
     public bool? MatchLevel3 { get; set; }
     public string? ReleaseType { get; set; }
     public CustomsDeclarationItem[] Items { get; set; } = [];
+    public string? DeclarantId { get; set; }
+    public string? DispatchCountryCode { get; set; }
 }
 
 public class CustomsDeclarationItem

--- a/src/Api/Data/Extensions/CustomsDeclarationExtensions.cs
+++ b/src/Api/Data/Extensions/CustomsDeclarationExtensions.cs
@@ -32,6 +32,8 @@ public static class CustomsDeclarationExtensions
                 customsDeclarationEvent
                     .ClearanceDecision?.Results?.Where(x => x.Level == 1)
                     .All(x => x.DecisionIsAMatch()) ?? false,
+            DeclarantId = customsDeclarationEvent.ClearanceRequest?.DeclarantId,
+            DispatchCountryCode = customsDeclarationEvent.ClearanceRequest?.DispatchCountryCode,
         };
 
         if (cd.MatchLevel1 == true)

--- a/src/Api/Data/ReportRepository.cs
+++ b/src/Api/Data/ReportRepository.cs
@@ -332,6 +332,8 @@ public class ReportRepository(IDbContext dbContext) : IReportRepository
                         DecisionReasons = item.DecisionReasons![0],
                         CheckCode = item.CheckCode,
                         Level = item.MatchLevel,
+                        DeclarantId = cd.DeclarantId,
+                        DispatchCountryCode = cd.DispatchCountryCode,
                     }
             )
             .OrderByDescending(x => x.Timestamp)
@@ -613,6 +615,8 @@ public class ReportRepository(IDbContext dbContext) : IReportRepository
                         CheckCode = item.CheckCode,
                         Level = item.MatchLevel,
                         Mode = item.Mode,
+                        DeclarantId = cd.DeclarantId,
+                        DispatchCountryCode = cd.DispatchCountryCode,
                     }
             )
             .OrderByDescending(x => x.Timestamp);

--- a/src/Api/Endpoints/Dtos/MatchResponse.cs
+++ b/src/Api/Endpoints/Dtos/MatchResponse.cs
@@ -52,6 +52,12 @@ public class MatchResponseV2
     [JsonPropertyName("mode")]
     public string? Mode { get; init; }
 
+    [JsonPropertyName("declarantId")]
+    public string? DeclarantId { get; init; }
+
+    [JsonPropertyName("dispatchCountryCode")]
+    public string? DispatchCountryCode { get; init; }
+
     public sealed class MatchResponseMap : ClassMap<MatchResponseV2>
     {
         public MatchResponseMap()
@@ -70,6 +76,8 @@ public class MatchResponseV2
             Map(m => m.DecisionReasons).Name("Decision reason");
             Map(m => m.Level);
             Map(m => m.Mode);
+            Map(m => m.DispatchCountryCode).Name("Dispatch country code");
+            Map(m => m.DeclarantId).Name("Declarant Id");
         }
     }
 }

--- a/tests/Api.IntegrationTests/Scenarios/Matches/DecisionTests.WhenRequestingData_ShouldBeOrdered.verified.json
+++ b/tests/Api.IntegrationTests/Scenarios/Matches/DecisionTests.WhenRequestingData_ShouldBeOrdered.verified.json
@@ -14,7 +14,9 @@
       "decision": "X00",
       "decisionReasons": null,
       "level": 1,
-      "mode": "Active"
+      "mode": "Active",
+      "declarantId": null,
+      "dispatchCountryCode": null
     },
     {
       "timestamp": "0001-01-01T00:00:00Z",
@@ -30,7 +32,9 @@
       "decision": "C03",
       "decisionReasons": null,
       "level": 1,
-      "mode": "Active"
+      "mode": "Active",
+      "declarantId": null,
+      "dispatchCountryCode": null
     },
     {
       "timestamp": "0001-01-01T00:00:00Z",
@@ -46,7 +50,9 @@
       "decision": "X00",
       "decisionReasons": "No match decision Reason",
       "level": 1,
-      "mode": "Active"
+      "mode": "Active",
+      "declarantId": null,
+      "dispatchCountryCode": null
     }
   ]
 }

--- a/tests/Api.IntegrationTests/Scenarios/Matches/DecisionTests.WhenSingleDecision_ShouldBeSingleCount_data_decisionCode=C03.verified.json
+++ b/tests/Api.IntegrationTests/Scenarios/Matches/DecisionTests.WhenSingleDecision_ShouldBeSingleCount_data_decisionCode=C03.verified.json
@@ -14,7 +14,9 @@
       "decision": "C03",
       "decisionReasons": null,
       "level": 1,
-      "mode": "Active"
+      "mode": "Active",
+      "declarantId": null,
+      "dispatchCountryCode": null
     }
   ]
 }

--- a/tests/Api.IntegrationTests/Scenarios/Releases/FinalisationTests.WhenMultipleFinalisationForDifferentMrn_AndOneOutsideFromAndTo_ShouldBeSingleCount_data.verified.json
+++ b/tests/Api.IntegrationTests/Scenarios/Releases/FinalisationTests.WhenMultipleFinalisationForDifferentMrn_AndOneOutsideFromAndTo_ShouldBeSingleCount_data.verified.json
@@ -14,7 +14,9 @@
       "decision": "C03",
       "decisionReasons": null,
       "level": 1,
-      "mode": null
+      "mode": null,
+      "declarantId": null,
+      "dispatchCountryCode": null
     },
     {
       "timestamp": "0001-01-01T00:00:00Z",
@@ -30,7 +32,9 @@
       "decision": "X00",
       "decisionReasons": "No match decision Reason",
       "level": 1,
-      "mode": null
+      "mode": null,
+      "declarantId": null,
+      "dispatchCountryCode": null
     }
   ]
 }

--- a/tests/Api.IntegrationTests/Scenarios/Releases/FinalisationTests.WhenMultipleFinalisationForSameMrn_AndChangeFromAutomaticToManual_ShouldBeSingleCount_data.verified.json
+++ b/tests/Api.IntegrationTests/Scenarios/Releases/FinalisationTests.WhenMultipleFinalisationForSameMrn_AndChangeFromAutomaticToManual_ShouldBeSingleCount_data.verified.json
@@ -14,7 +14,9 @@
       "decision": "C03",
       "decisionReasons": null,
       "level": 1,
-      "mode": null
+      "mode": null,
+      "declarantId": null,
+      "dispatchCountryCode": null
     },
     {
       "timestamp": "0001-01-01T00:00:00Z",
@@ -30,7 +32,9 @@
       "decision": "X00",
       "decisionReasons": "No match decision Reason",
       "level": 1,
-      "mode": null
+      "mode": null,
+      "declarantId": null,
+      "dispatchCountryCode": null
     }
   ]
 }

--- a/tests/Api.IntegrationTests/Scenarios/Releases/FinalisationTests.WhenMultipleFinalisationForSameMrn_ShouldBeSingleCount_data.verified.json
+++ b/tests/Api.IntegrationTests/Scenarios/Releases/FinalisationTests.WhenMultipleFinalisationForSameMrn_ShouldBeSingleCount_data.verified.json
@@ -14,7 +14,9 @@
       "decision": "C03",
       "decisionReasons": null,
       "level": 1,
-      "mode": null
+      "mode": null,
+      "declarantId": null,
+      "dispatchCountryCode": null
     },
     {
       "timestamp": "0001-01-01T00:00:00Z",
@@ -30,7 +32,9 @@
       "decision": "X00",
       "decisionReasons": "No match decision Reason",
       "level": 1,
-      "mode": null
+      "mode": null,
+      "declarantId": null,
+      "dispatchCountryCode": null
     }
   ]
 }

--- a/tests/Api.IntegrationTests/Scenarios/Releases/FinalisationTests.WhenRequestingData_ShouldBeOrdered.verified.json
+++ b/tests/Api.IntegrationTests/Scenarios/Releases/FinalisationTests.WhenRequestingData_ShouldBeOrdered.verified.json
@@ -14,7 +14,9 @@
       "decision": "C03",
       "decisionReasons": null,
       "level": 1,
-      "mode": null
+      "mode": null,
+      "declarantId": null,
+      "dispatchCountryCode": null
     },
     {
       "timestamp": "0001-01-01T00:00:00Z",
@@ -30,7 +32,9 @@
       "decision": "X00",
       "decisionReasons": "No match decision Reason",
       "level": 1,
-      "mode": null
+      "mode": null,
+      "declarantId": null,
+      "dispatchCountryCode": null
     },
     {
       "timestamp": "0001-01-01T00:00:00Z",
@@ -46,7 +50,9 @@
       "decision": "C03",
       "decisionReasons": null,
       "level": 1,
-      "mode": null
+      "mode": null,
+      "declarantId": null,
+      "dispatchCountryCode": null
     },
     {
       "timestamp": "0001-01-01T00:00:00Z",
@@ -62,7 +68,9 @@
       "decision": "X00",
       "decisionReasons": "No match decision Reason",
       "level": 1,
-      "mode": null
+      "mode": null,
+      "declarantId": null,
+      "dispatchCountryCode": null
     }
   ]
 }

--- a/tests/Api.IntegrationTests/Scenarios/Releases/FinalisationTests.WhenSingleFinalisation_ShouldBeSingleCount_data_isManualRelease=True_isCancelled=False.verified.json
+++ b/tests/Api.IntegrationTests/Scenarios/Releases/FinalisationTests.WhenSingleFinalisation_ShouldBeSingleCount_data_isManualRelease=True_isCancelled=False.verified.json
@@ -14,7 +14,9 @@
       "decision": "C03",
       "decisionReasons": null,
       "level": 1,
-      "mode": null
+      "mode": null,
+      "declarantId": null,
+      "dispatchCountryCode": null
     },
     {
       "timestamp": "0001-01-01T00:00:00Z",
@@ -30,7 +32,9 @@
       "decision": "X00",
       "decisionReasons": "No match decision Reason",
       "level": 1,
-      "mode": null
+      "mode": null,
+      "declarantId": null,
+      "dispatchCountryCode": null
     }
   ]
 }

--- a/tests/Api.Tests/Consumers/ClearanceDecisionResultExtensionsTests.MapToInternalCustomsDeclaration.verified.json
+++ b/tests/Api.Tests/Consumers/ClearanceDecisionResultExtensionsTests.MapToInternalCustomsDeclaration.verified.json
@@ -76,5 +76,7 @@
       "MatchLevel": 1,
       "RuleName": "UnlinkedNotificationDecisionRule"
     }
-  ]
+  ],
+  "DeclarantId": "GB269573944000",
+  "DispatchCountryCode": "IT"
 }

--- a/tests/Api.Tests/Endpoints/Matches/GetMatchesDataTests.Get_WhenAuthorized_AndRequestingCsv_ShouldBeOk_mrn=mrn'1_match=True_matchLevel=null.verified.txt
+++ b/tests/Api.Tests/Endpoints/Matches/GetMatchesDataTests.Get_WhenAuthorized_AndRequestingCsv_ShouldBeOk_mrn=mrn'1_match=True_matchLevel=null.verified.txt
@@ -1,3 +1,3 @@
-﻿Last updated,MRN,Item number,Commodity code,Check code,Description,Quantity/Weight,CHED reference,Match,Authority,Decision,Decision reason,Level,Mode
-09/15/2025 16:31:05,mrn,1,commodityCode1,H222,description1,,chedReference1,Yes,authority1,X00,,,
-09/15/2025 16:41:05,mrn2,2,commodityCode2,H222,description2,,chedReference1,Yes,authority2,X00,,,
+﻿Last updated,MRN,Item number,Commodity code,Check code,Description,Quantity/Weight,CHED reference,Match,Authority,Decision,Decision reason,Level,Mode,Dispatch country code,Declarant Id
+09/15/2025 16:31:05,mrn,1,commodityCode1,H222,description1,,chedReference1,Yes,authority1,X00,,,,,
+09/15/2025 16:41:05,mrn2,2,commodityCode2,H222,description2,,chedReference1,Yes,authority2,X00,,,,,

--- a/tests/Api.Tests/Endpoints/Matches/GetMatchesDataTests.Get_WhenAuthorized_AndRequestingCsv_ShouldBeOk_mrn=mrn-1_match=True_matchLevel=null.verified.txt
+++ b/tests/Api.Tests/Endpoints/Matches/GetMatchesDataTests.Get_WhenAuthorized_AndRequestingCsv_ShouldBeOk_mrn=mrn-1_match=True_matchLevel=null.verified.txt
@@ -1,3 +1,3 @@
-﻿Last updated,MRN,Item number,Commodity code,Check code,Description,Quantity/Weight,CHED reference,Match,Authority,Decision,Decision reason,Level,Mode
-09/15/2025 16:31:05,mrn,1,commodityCode1,H222,description1,,chedReference1,Yes,authority1,X00,,,
-09/15/2025 16:41:05,mrn2,2,commodityCode2,H222,description2,,chedReference1,Yes,authority2,X00,,,
+﻿Last updated,MRN,Item number,Commodity code,Check code,Description,Quantity/Weight,CHED reference,Match,Authority,Decision,Decision reason,Level,Mode,Dispatch country code,Declarant Id
+09/15/2025 16:31:05,mrn,1,commodityCode1,H222,description1,,chedReference1,Yes,authority1,X00,,,,,
+09/15/2025 16:41:05,mrn2,2,commodityCode2,H222,description2,,chedReference1,Yes,authority2,X00,,,,,

--- a/tests/Api.Tests/Endpoints/Matches/GetMatchesDataTests.Get_WhenAuthorized_AndRequestingCsv_ShouldBeOk_mrn=mrn_match=False_matchLevel=null.verified.txt
+++ b/tests/Api.Tests/Endpoints/Matches/GetMatchesDataTests.Get_WhenAuthorized_AndRequestingCsv_ShouldBeOk_mrn=mrn_match=False_matchLevel=null.verified.txt
@@ -1,3 +1,3 @@
-﻿Last updated,MRN,Item number,Commodity code,Check code,Description,Quantity/Weight,CHED reference,Match,Authority,Decision,Decision reason,Level,Mode
-09/15/2025 16:31:05,mrn,1,commodityCode1,H222,description1,,chedReference1,Yes,authority1,X00,,,
-09/15/2025 16:41:05,mrn2,2,commodityCode2,H222,description2,,chedReference1,Yes,authority2,X00,,,
+﻿Last updated,MRN,Item number,Commodity code,Check code,Description,Quantity/Weight,CHED reference,Match,Authority,Decision,Decision reason,Level,Mode,Dispatch country code,Declarant Id
+09/15/2025 16:31:05,mrn,1,commodityCode1,H222,description1,,chedReference1,Yes,authority1,X00,,,,,
+09/15/2025 16:41:05,mrn2,2,commodityCode2,H222,description2,,chedReference1,Yes,authority2,X00,,,,,

--- a/tests/Api.Tests/Endpoints/Matches/GetMatchesDataTests.Get_WhenAuthorized_AndRequestingCsv_ShouldBeOk_mrn=mrn_match=True_matchLevel=1.verified.txt
+++ b/tests/Api.Tests/Endpoints/Matches/GetMatchesDataTests.Get_WhenAuthorized_AndRequestingCsv_ShouldBeOk_mrn=mrn_match=True_matchLevel=1.verified.txt
@@ -1,3 +1,3 @@
-﻿Last updated,MRN,Item number,Commodity code,Check code,Description,Quantity/Weight,CHED reference,Match,Authority,Decision,Decision reason,Level,Mode
-09/15/2025 16:31:05,mrn,1,commodityCode1,H222,description1,,chedReference1,Yes,authority1,X00,,,
-09/15/2025 16:41:05,mrn2,2,commodityCode2,H222,description2,,chedReference1,Yes,authority2,X00,,,
+﻿Last updated,MRN,Item number,Commodity code,Check code,Description,Quantity/Weight,CHED reference,Match,Authority,Decision,Decision reason,Level,Mode,Dispatch country code,Declarant Id
+09/15/2025 16:31:05,mrn,1,commodityCode1,H222,description1,,chedReference1,Yes,authority1,X00,,,,,
+09/15/2025 16:41:05,mrn2,2,commodityCode2,H222,description2,,chedReference1,Yes,authority2,X00,,,,,

--- a/tests/Api.Tests/Endpoints/Matches/GetMatchesDataTests.Get_WhenAuthorized_AndRequestingCsv_ShouldBeOk_mrn=mrn_match=True_matchLevel=2.verified.txt
+++ b/tests/Api.Tests/Endpoints/Matches/GetMatchesDataTests.Get_WhenAuthorized_AndRequestingCsv_ShouldBeOk_mrn=mrn_match=True_matchLevel=2.verified.txt
@@ -1,3 +1,3 @@
-﻿Last updated,MRN,Item number,Commodity code,Check code,Description,Quantity/Weight,CHED reference,Match,Authority,Decision,Decision reason,Level,Mode
-09/15/2025 16:31:05,mrn,1,commodityCode1,H222,description1,,chedReference1,Yes,authority1,X00,,,
-09/15/2025 16:41:05,mrn2,2,commodityCode2,H222,description2,,chedReference1,Yes,authority2,X00,,,
+﻿Last updated,MRN,Item number,Commodity code,Check code,Description,Quantity/Weight,CHED reference,Match,Authority,Decision,Decision reason,Level,Mode,Dispatch country code,Declarant Id
+09/15/2025 16:31:05,mrn,1,commodityCode1,H222,description1,,chedReference1,Yes,authority1,X00,,,,,
+09/15/2025 16:41:05,mrn2,2,commodityCode2,H222,description2,,chedReference1,Yes,authority2,X00,,,,,

--- a/tests/Api.Tests/Endpoints/Matches/GetMatchesDataTests.Get_WhenAuthorized_AndRequestingCsv_ShouldBeOk_mrn=mrn_match=True_matchLevel=3.verified.txt
+++ b/tests/Api.Tests/Endpoints/Matches/GetMatchesDataTests.Get_WhenAuthorized_AndRequestingCsv_ShouldBeOk_mrn=mrn_match=True_matchLevel=3.verified.txt
@@ -1,3 +1,3 @@
-﻿Last updated,MRN,Item number,Commodity code,Check code,Description,Quantity/Weight,CHED reference,Match,Authority,Decision,Decision reason,Level,Mode
-09/15/2025 16:31:05,mrn,1,commodityCode1,H222,description1,,chedReference1,Yes,authority1,X00,,,
-09/15/2025 16:41:05,mrn2,2,commodityCode2,H222,description2,,chedReference1,Yes,authority2,X00,,,
+﻿Last updated,MRN,Item number,Commodity code,Check code,Description,Quantity/Weight,CHED reference,Match,Authority,Decision,Decision reason,Level,Mode,Dispatch country code,Declarant Id
+09/15/2025 16:31:05,mrn,1,commodityCode1,H222,description1,,chedReference1,Yes,authority1,X00,,,,,
+09/15/2025 16:41:05,mrn2,2,commodityCode2,H222,description2,,chedReference1,Yes,authority2,X00,,,,,

--- a/tests/Api.Tests/Endpoints/Matches/GetMatchesDataTests.Get_WhenAuthorized_AndRequestingCsv_ShouldBeOk_mrn=mrn_match=True_matchLevel=null.verified.txt
+++ b/tests/Api.Tests/Endpoints/Matches/GetMatchesDataTests.Get_WhenAuthorized_AndRequestingCsv_ShouldBeOk_mrn=mrn_match=True_matchLevel=null.verified.txt
@@ -1,3 +1,3 @@
-﻿Last updated,MRN,Item number,Commodity code,Check code,Description,Quantity/Weight,CHED reference,Match,Authority,Decision,Decision reason,Level,Mode
-09/15/2025 16:31:05,mrn,1,commodityCode1,H222,description1,,chedReference1,Yes,authority1,X00,,,
-09/15/2025 16:41:05,mrn2,2,commodityCode2,H222,description2,,chedReference1,Yes,authority2,X00,,,
+﻿Last updated,MRN,Item number,Commodity code,Check code,Description,Quantity/Weight,CHED reference,Match,Authority,Decision,Decision reason,Level,Mode,Dispatch country code,Declarant Id
+09/15/2025 16:31:05,mrn,1,commodityCode1,H222,description1,,chedReference1,Yes,authority1,X00,,,,,
+09/15/2025 16:41:05,mrn2,2,commodityCode2,H222,description2,,chedReference1,Yes,authority2,X00,,,,,

--- a/tests/Api.Tests/Endpoints/Matches/GetMatchesDataTests.Get_WhenAuthorized_ShouldBeOk.verified.json
+++ b/tests/Api.Tests/Endpoints/Matches/GetMatchesDataTests.Get_WhenAuthorized_ShouldBeOk.verified.json
@@ -14,7 +14,9 @@
       "decision": "X00",
       "decisionReasons": null,
       "level": null,
-      "mode": null
+      "mode": null,
+      "declarantId": null,
+      "dispatchCountryCode": null
     },
     {
       "timestamp": "2025-09-15T16:41:05Z",
@@ -30,7 +32,9 @@
       "decision": "X00",
       "decisionReasons": null,
       "level": null,
-      "mode": null
+      "mode": null,
+      "declarantId": null,
+      "dispatchCountryCode": null
     }
   ]
 }

--- a/tests/Api.Tests/Endpoints/Releases/GetReleasesDataTests.Get_WhenAuthorized_AndRequestingCsv_ShouldBeOk_mrn1=mrn'1.verified.txt
+++ b/tests/Api.Tests/Endpoints/Releases/GetReleasesDataTests.Get_WhenAuthorized_AndRequestingCsv_ShouldBeOk_mrn1=mrn'1.verified.txt
@@ -1,3 +1,3 @@
-﻿Last updated,MRN,Item number,Commodity code,Check code,Description,Quantity/Weight,CHED reference,Match,Authority,Decision,Decision reason,Level,Mode
-09/15/2025 16:31:05,mrn1,1,commodityCode1,H222,description1,,chedReference1,Yes,authority1,X00,,,
-09/15/2025 16:41:05,mrn2,2,commodityCode2,H222,description2,,chedReference1,Yes,authority2,X00,,,
+﻿Last updated,MRN,Item number,Commodity code,Check code,Description,Quantity/Weight,CHED reference,Match,Authority,Decision,Decision reason,Level,Mode,Dispatch country code,Declarant Id
+09/15/2025 16:31:05,mrn1,1,commodityCode1,H222,description1,,chedReference1,Yes,authority1,X00,,,,,
+09/15/2025 16:41:05,mrn2,2,commodityCode2,H222,description2,,chedReference1,Yes,authority2,X00,,,,,

--- a/tests/Api.Tests/Endpoints/Releases/GetReleasesDataTests.Get_WhenAuthorized_AndRequestingCsv_ShouldBeOk_mrn1=mrn-1.verified.txt
+++ b/tests/Api.Tests/Endpoints/Releases/GetReleasesDataTests.Get_WhenAuthorized_AndRequestingCsv_ShouldBeOk_mrn1=mrn-1.verified.txt
@@ -1,3 +1,3 @@
-﻿Last updated,MRN,Item number,Commodity code,Check code,Description,Quantity/Weight,CHED reference,Match,Authority,Decision,Decision reason,Level,Mode
-09/15/2025 16:31:05,mrn1,1,commodityCode1,H222,description1,,chedReference1,Yes,authority1,X00,,,
-09/15/2025 16:41:05,mrn2,2,commodityCode2,H222,description2,,chedReference1,Yes,authority2,X00,,,
+﻿Last updated,MRN,Item number,Commodity code,Check code,Description,Quantity/Weight,CHED reference,Match,Authority,Decision,Decision reason,Level,Mode,Dispatch country code,Declarant Id
+09/15/2025 16:31:05,mrn1,1,commodityCode1,H222,description1,,chedReference1,Yes,authority1,X00,,,,,
+09/15/2025 16:41:05,mrn2,2,commodityCode2,H222,description2,,chedReference1,Yes,authority2,X00,,,,,

--- a/tests/Api.Tests/Endpoints/Releases/GetReleasesDataTests.Get_WhenAuthorized_AndRequestingCsv_ShouldBeOk_mrn1=mrn1.verified.txt
+++ b/tests/Api.Tests/Endpoints/Releases/GetReleasesDataTests.Get_WhenAuthorized_AndRequestingCsv_ShouldBeOk_mrn1=mrn1.verified.txt
@@ -1,3 +1,3 @@
-﻿Last updated,MRN,Item number,Commodity code,Check code,Description,Quantity/Weight,CHED reference,Match,Authority,Decision,Decision reason,Level,Mode
-09/15/2025 16:31:05,mrn1,1,commodityCode1,H222,description1,,chedReference1,Yes,authority1,X00,,,
-09/15/2025 16:41:05,mrn2,2,commodityCode2,H222,description2,,chedReference1,Yes,authority2,X00,,,
+﻿Last updated,MRN,Item number,Commodity code,Check code,Description,Quantity/Weight,CHED reference,Match,Authority,Decision,Decision reason,Level,Mode,Dispatch country code,Declarant Id
+09/15/2025 16:31:05,mrn1,1,commodityCode1,H222,description1,,chedReference1,Yes,authority1,X00,,,,,
+09/15/2025 16:41:05,mrn2,2,commodityCode2,H222,description2,,chedReference1,Yes,authority2,X00,,,,,

--- a/tests/Api.Tests/Endpoints/Releases/GetReleasesDataTests.Get_WhenAuthorized_ShouldBeOk.verified.json
+++ b/tests/Api.Tests/Endpoints/Releases/GetReleasesDataTests.Get_WhenAuthorized_ShouldBeOk.verified.json
@@ -14,7 +14,9 @@
       "decision": "X00",
       "decisionReasons": null,
       "level": null,
-      "mode": null
+      "mode": null,
+      "declarantId": null,
+      "dispatchCountryCode": null
     },
     {
       "timestamp": "2025-09-15T16:41:05Z",
@@ -30,7 +32,9 @@
       "decision": "X00",
       "decisionReasons": null,
       "level": null,
-      "mode": null
+      "mode": null,
+      "declarantId": null,
+      "dispatchCountryCode": null
     }
   ]
 }


### PR DESCRIPTION
Capture Declarant ID and Dispatch Country Code from clearance requests and expose them in match and release reports (JSON and CSV). This enriches the data available for customs declarations.
