### PR TITLE
CDMS-1462: Add API endpoint for declaration match summary by level and region

### DIFF
--- a/src/Api/Data/IReportRepository.cs
+++ b/src/Api/Data/IReportRepository.cs
@@ -36,6 +36,12 @@ public interface IReportRepository
         CancellationToken cancellationToken
     );
 
+    Task<DeclarationSummary> GetMatchesSummaryByLevelByRegion(
+        DateTime from,
+        DateTime to,
+        CancellationToken cancellationToken
+    );
+
     Task<IReadOnlyList<MatchesBucket>> GetMatchesIntervals(
         DateTime from,
         DateTime to,

--- a/src/Api/Data/MatchesSummaryByLevel.cs
+++ b/src/Api/Data/MatchesSummaryByLevel.cs
@@ -4,3 +4,7 @@ public record MatchesSummaryByLevel(int Total, int Level1, int Level2, int Level
 {
     public static MatchesSummaryByLevel Empty => new(0, 0, 0, 0);
 }
+
+public sealed record RegionSummary(int Total, MatchesSummaryByLevel Match, MatchesSummaryByLevel NoMatch);
+
+public sealed record DeclarationSummary(int Total, RegionSummary Eu, RegionSummary Row);

--- a/src/Api/Data/RegionSummaryBuilder.cs
+++ b/src/Api/Data/RegionSummaryBuilder.cs
@@ -1,0 +1,35 @@
+using Defra.TradeImportsReportingApi.Api.Data.Entities;
+
+namespace Defra.TradeImportsReportingApi.Api.Data;
+
+public static class RegionSummaryBuilder
+{
+    public static RegionSummary ToRegionSummary(this IEnumerable<CustomsDeclaration> declarations)
+    {
+        var items = declarations.ToList();
+
+        var matches = items
+            .Where(x => x.MatchLevel1 == true || x.MatchLevel2 == true || x.MatchLevel3 == true)
+            .ToList();
+
+        var noMatches = items
+            .Where(x => x.MatchLevel1 == false || x.MatchLevel2 == false || x.MatchLevel3 == false)
+            .ToList();
+
+        return new RegionSummary(
+            Total: items.Count,
+            Match: new MatchesSummaryByLevel(
+                Total: matches.Count,
+                Level1: matches.Count(x => x.MatchLevel1 == true),
+                Level2: matches.Count(x => x.MatchLevel2 == true),
+                Level3: matches.Count(x => x.MatchLevel3 == true)
+            ),
+            NoMatch: new MatchesSummaryByLevel(
+                Total: noMatches.Count,
+                Level1: noMatches.Count(x => x.MatchLevel1 == false),
+                Level2: noMatches.Count(x => x.MatchLevel2 == false),
+                Level3: noMatches.Count(x => x.MatchLevel3 == false)
+            )
+        );
+    }
+}

--- a/src/Api/Data/ReportRepository.cs
+++ b/src/Api/Data/ReportRepository.cs
@@ -665,8 +665,8 @@ public class ReportRepository(IDbContext dbContext) : IReportRepository
 
         var result = new DeclarationSummary(
             Total: declarations.Count,
-            Eu: BuildRegionSummary(eu),
-            Row: BuildRegionSummary(row)
+            Eu: eu.ToRegionSummary(),
+            Row: row.ToRegionSummary()
         );
 
         return result;
@@ -1336,35 +1336,6 @@ public class ReportRepository(IDbContext dbContext) : IReportRepository
                     { "sortBy", new BsonDocument(sortByField, -1) },
                     { "output", new BsonDocument(returnField, $"${returnField}") },
                 }
-            )
-        );
-    }
-
-    static RegionSummary BuildRegionSummary(IEnumerable<CustomsDeclaration> declarations)
-    {
-        var items = declarations.ToList();
-
-        var matches = items
-            .Where(x => x.MatchLevel1 == true || x.MatchLevel2 == true || x.MatchLevel3 == true)
-            .ToList();
-
-        var noMatches = items
-            .Where(x => x.MatchLevel1 != true && x.MatchLevel2 != true && x.MatchLevel3 != true)
-            .ToList();
-
-        return new RegionSummary(
-            Total: items.Count,
-            Match: new MatchesSummaryByLevel(
-                Total: matches.Count,
-                Level1: matches.Count(x => x.MatchLevel1 == true),
-                Level2: matches.Count(x => x.MatchLevel2 == true),
-                Level3: matches.Count(x => x.MatchLevel3 == true)
-            ),
-            NoMatch: new MatchesSummaryByLevel(
-                Total: noMatches.Count,
-                Level1: noMatches.Count(x => x.MatchLevel1 == true),
-                Level2: noMatches.Count(x => x.MatchLevel2 == true),
-                Level3: noMatches.Count(x => x.MatchLevel3 == true)
             )
         );
     }

--- a/src/Api/Data/ReportRepository.cs
+++ b/src/Api/Data/ReportRepository.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Defra.TradeImportsReportingApi.Api.Data.Entities;
 using Defra.TradeImportsReportingApi.Api.Endpoints.Dtos;
+using Defra.TradeImportsReportingApi.Api.Utils;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Conventions;
 using MongoDB.Driver;
@@ -644,6 +645,31 @@ public class ReportRepository(IDbContext dbContext) : IReportRepository
             ));
 
         return await query.FirstOrDefaultAsync(cancellationToken) ?? MatchesSummaryByLevel.Empty;
+    }
+
+    public async Task<DeclarationSummary> GetMatchesSummaryByLevelByRegion(
+        DateTime from,
+        DateTime to,
+        CancellationToken cancellationToken
+    )
+    {
+        GuardUtc(from, to);
+
+        var declarations = await dbContext
+            .CustomsDeclarations.AsQueryable()
+            .Where(x => x.MrnCreated >= from && x.MrnCreated < to)
+            .ToListAsync(cancellationToken);
+
+        var eu = declarations.Where(x => Region.IsEu(x.DispatchCountryCode)).ToList();
+        var row = declarations.Where(x => !Region.IsEu(x.DispatchCountryCode)).ToList();
+
+        var result = new DeclarationSummary(
+            Total: declarations.Count,
+            Eu: BuildRegionSummary(eu),
+            Row: BuildRegionSummary(row)
+        );
+
+        return result;
     }
 
     public async Task<ClearanceRequestsSummary> GetClearanceRequestsSummary(
@@ -1310,6 +1336,35 @@ public class ReportRepository(IDbContext dbContext) : IReportRepository
                     { "sortBy", new BsonDocument(sortByField, -1) },
                     { "output", new BsonDocument(returnField, $"${returnField}") },
                 }
+            )
+        );
+    }
+
+    static RegionSummary BuildRegionSummary(IEnumerable<CustomsDeclaration> declarations)
+    {
+        var items = declarations.ToList();
+
+        var matches = items
+            .Where(x => x.MatchLevel1 == true || x.MatchLevel2 == true || x.MatchLevel3 == true)
+            .ToList();
+
+        var noMatches = items
+            .Where(x => x.MatchLevel1 != true && x.MatchLevel2 != true && x.MatchLevel3 != true)
+            .ToList();
+
+        return new RegionSummary(
+            Total: items.Count,
+            Match: new MatchesSummaryByLevel(
+                Total: matches.Count,
+                Level1: matches.Count(x => x.MatchLevel1 == true),
+                Level2: matches.Count(x => x.MatchLevel2 == true),
+                Level3: matches.Count(x => x.MatchLevel3 == true)
+            ),
+            NoMatch: new MatchesSummaryByLevel(
+                Total: noMatches.Count,
+                Level1: noMatches.Count(x => x.MatchLevel1 == true),
+                Level2: noMatches.Count(x => x.MatchLevel2 == true),
+                Level3: noMatches.Count(x => x.MatchLevel3 == true)
             )
         );
     }

--- a/src/Api/Endpoints/MatchesEndpoints.cs
+++ b/src/Api/Endpoints/MatchesEndpoints.cs
@@ -49,6 +49,16 @@ public static class MatchesEndpoints
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status500InternalServerError)
             .RequireAuthorization();
+
+        app.MapGet("matches/summary/levels-by-region", MatchesSummaryByLevelByRegion)
+            .WithName("MatchesSummaryByLevelByRegion")
+            .WithTags(DecisionsTag)
+            .WithSummary("Get matches summary counts by level by group")
+            .WithDescription(Descriptions.SearchablePeriod)
+            .Produces<DeclarationSummary>()
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status500InternalServerError)
+            .RequireAuthorization();
     }
 
     /// <param name="from" example="2025-09-10T11:08:48Z">ISO 8609 UTC only</param>
@@ -97,6 +107,34 @@ public static class MatchesEndpoints
         var matchesSummaryByLevel = await reportRepository.GetMatchesSummaryByLevel(from, to, cancellationToken);
 
         return Results.Ok(matchesSummaryByLevel.ToResponse());
+    }
+
+    /// <param name="from" example="2025-09-10T11:08:48Z">ISO 8609 UTC only</param>
+    /// <param name="to" example="2025-09-11T11:08:48Z">ISO 8609 UTC only</param>
+    /// <param name="reportRepository"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    [HttpGet]
+    private static async Task<IResult> MatchesSummaryByLevelByRegion(
+        [FromQuery] DateTime from,
+        [FromQuery] DateTime to,
+        [FromServices] IReportRepository reportRepository,
+        CancellationToken cancellationToken
+    )
+    {
+        var errors = Request.Validate(from, to);
+        if (errors.Count > 0)
+        {
+            return Results.ValidationProblem(errors);
+        }
+
+        var matchesSummaryByLevel = await reportRepository.GetMatchesSummaryByLevelByRegion(
+            from,
+            to,
+            cancellationToken
+        );
+
+        return Results.Ok(matchesSummaryByLevel);
     }
 
     /// <param name="from" example="2025-09-10T11:08:48Z">ISO 8609 UTC only</param>

--- a/src/Api/Utils/Region.cs
+++ b/src/Api/Utils/Region.cs
@@ -1,0 +1,41 @@
+namespace Defra.TradeImportsReportingApi.Api.Utils;
+
+public static class Region
+{
+    private static readonly string[] s_eu =
+    [
+        "AT",
+        "BE",
+        "BG",
+        "HR",
+        "CY",
+        "CZ",
+        "DK",
+        "EE",
+        "FI",
+        "FR",
+        "DE",
+        "GR",
+        "HU",
+        "IS",
+        "IE",
+        "IT",
+        "LV",
+        "LI",
+        "LT",
+        "LU",
+        "MT",
+        "NL",
+        "NO",
+        "PL",
+        "PT",
+        "RO",
+        "SK",
+        "SI",
+        "ES",
+        "SE",
+        "CH",
+    ];
+
+    public static bool IsEu(string? region) => s_eu.Contains(region);
+}

--- a/tests/Api.Tests/Data/RegionSummaryBuilderTests.When_building_region_summary_counts_should_be_correct.verified.txt
+++ b/tests/Api.Tests/Data/RegionSummaryBuilderTests.When_building_region_summary_counts_should_be_correct.verified.txt
@@ -1,0 +1,15 @@
+﻿{
+  Total: 4,
+  Match: {
+    Total: 3,
+    Level1: 3,
+    Level2: 2,
+    Level3: 1
+  },
+  NoMatch: {
+    Total: 3,
+    Level1: 1,
+    Level2: 2,
+    Level3: 3
+  }
+}

--- a/tests/Api.Tests/Data/RequestMetricsTests.cs
+++ b/tests/Api.Tests/Data/RequestMetricsTests.cs
@@ -1,0 +1,41 @@
+using System.Diagnostics.Metrics;
+using Defra.TradeImportsReportingApi.Api.Data;
+using Defra.TradeImportsReportingApi.Api.Data.Entities;
+using Defra.TradeImportsReportingApi.Api.Metrics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.Metrics.Testing;
+using WireMock.ResponseBuilders;
+
+namespace Defra.TradeImportsReportingApi.Api.Tests.Data;
+
+public class RegionSummaryBuilderTests
+{
+    private CustomsDeclaration CreateCustomsDeclaration(bool level1Match, bool level2Match, bool level3Match)
+    {
+        return new CustomsDeclaration
+        {
+            MatchLevel1 = level1Match,
+            MatchLevel2 = level2Match,
+            MatchLevel3 = level3Match,
+            Id = Guid.NewGuid().ToString(),
+            MrnCreated = DateTime.UtcNow,
+            Timestamp = DateTime.UtcNow,
+        };
+    }
+
+    [Fact]
+    public async Task When_building_region_summary_counts_should_be_correct()
+    {
+        CustomsDeclaration[] customsDeclarations =
+        [
+            CreateCustomsDeclaration(true, true, true),
+            CreateCustomsDeclaration(true, true, false),
+            CreateCustomsDeclaration(true, false, false),
+            CreateCustomsDeclaration(false, false, false),
+        ];
+
+        var regionSummary = customsDeclarations.ToRegionSummary();
+
+        await Verify(regionSummary);
+    }
+}

--- a/tests/Api.Tests/Endpoints/Matches/GetMatchesSummaryByLevelByRegionTests.Get_WhenAuthorized_AndDateSpanGreaterThanAllowedDays_ShouldBeBadRequest.verified.json
+++ b/tests/Api.Tests/Endpoints/Matches/GetMatchesSummaryByLevelByRegionTests.Get_WhenAuthorized_AndDateSpanGreaterThanAllowedDays_ShouldBeBadRequest.verified.json
@@ -1,0 +1,11 @@
+﻿{
+  "type": "https://tools.ietf.org/html/rfc9110#section-15.5.1",
+  "title": "One or more validation errors occurred.",
+  "status": 400,
+  "errors": {
+    "": [
+      "date span cannot be greater than 122 days"
+    ]
+  },
+  "traceId": "{Scrubbed}"
+}

--- a/tests/Api.Tests/Endpoints/Matches/GetMatchesSummaryByLevelByRegionTests.Get_WhenAuthorized_AndFromAfterTo_ShouldBeBadRequest.verified.json
+++ b/tests/Api.Tests/Endpoints/Matches/GetMatchesSummaryByLevelByRegionTests.Get_WhenAuthorized_AndFromAfterTo_ShouldBeBadRequest.verified.json
@@ -1,0 +1,11 @@
+﻿{
+  "type": "https://tools.ietf.org/html/rfc9110#section-15.5.1",
+  "title": "One or more validation errors occurred.",
+  "status": 400,
+  "errors": {
+    "from": [
+      "from cannot be greater than to"
+    ]
+  },
+  "traceId": "{Scrubbed}"
+}

--- a/tests/Api.Tests/Endpoints/Matches/GetMatchesSummaryByLevelByRegionTests.Get_WhenAuthorized_AndFromAndToNotUtc_ShouldBeBadRequest.verified.json
+++ b/tests/Api.Tests/Endpoints/Matches/GetMatchesSummaryByLevelByRegionTests.Get_WhenAuthorized_AndFromAndToNotUtc_ShouldBeBadRequest.verified.json
@@ -1,0 +1,14 @@
+﻿{
+  "type": "https://tools.ietf.org/html/rfc9110#section-15.5.1",
+  "title": "One or more validation errors occurred.",
+  "status": 400,
+  "errors": {
+    "from": [
+      "date must be UTC"
+    ],
+    "to": [
+      "date must be UTC"
+    ]
+  },
+  "traceId": "{Scrubbed}"
+}

--- a/tests/Api.Tests/Endpoints/Matches/GetMatchesSummaryByLevelByRegionTests.Get_WhenAuthorized_ShouldBeOk.verified.json
+++ b/tests/Api.Tests/Endpoints/Matches/GetMatchesSummaryByLevelByRegionTests.Get_WhenAuthorized_ShouldBeOk.verified.json
@@ -1,0 +1,33 @@
+﻿{
+  "total": 100,
+  "eu": {
+    "total": 80,
+    "match": {
+      "total": 60,
+      "level1": 55,
+      "level2": 50,
+      "level3": 45
+    },
+    "noMatch": {
+      "total": 60,
+      "level1": 55,
+      "level2": 50,
+      "level3": 45
+    }
+  },
+  "row": {
+    "total": 100,
+    "match": {
+      "total": 60,
+      "level1": 55,
+      "level2": 50,
+      "level3": 45
+    },
+    "noMatch": {
+      "total": 60,
+      "level1": 55,
+      "level2": 50,
+      "level3": 45
+    }
+  }
+}

--- a/tests/Api.Tests/Endpoints/Matches/GetMatchesSummaryByLevelByRegionTests.cs
+++ b/tests/Api.Tests/Endpoints/Matches/GetMatchesSummaryByLevelByRegionTests.cs
@@ -1,0 +1,120 @@
+using System.Net;
+using Defra.TradeImportsReportingApi.Api.Data;
+using Defra.TradeImportsReportingApi.Api.Endpoints;
+using Defra.TradeImportsReportingApi.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Xunit.Abstractions;
+
+namespace Defra.TradeImportsReportingApi.Api.Tests.Endpoints.Matches;
+
+public class GetMatchesSummaryByLevelByRegionTests(ApiWebApplicationFactory factory, ITestOutputHelper outputHelper)
+    : EndpointTestBase(factory, outputHelper)
+{
+    private IReportRepository MockReportRepository { get; } = Substitute.For<IReportRepository>();
+
+    protected override void ConfigureTestServices(IServiceCollection services)
+    {
+        base.ConfigureTestServices(services);
+
+        services.AddTransient<IReportRepository>(_ => MockReportRepository);
+    }
+
+    [Fact]
+    public async Task Get_WhenUnauthorized_ShouldBeUnauthorized()
+    {
+        var client = CreateClient(addDefaultAuthorizationHeader: false);
+
+        var response = await client.GetAsync(Testing.Endpoints.Matches.SummaryByLevelByRegion());
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Get_WhenAuthorized_ShouldBeOk()
+    {
+        var client = CreateClient();
+        var from = new DateTime(2025, 9, 3, 15, 0, 0, DateTimeKind.Utc);
+        var to = new DateTime(2025, 9, 3, 16, 0, 0, DateTimeKind.Utc);
+        MockReportRepository
+            .GetMatchesSummaryByLevelByRegion(from, to, Arg.Any<CancellationToken>())
+            .Returns(
+                new DeclarationSummary(
+                    100,
+                    new RegionSummary(
+                        80,
+                        new MatchesSummaryByLevel(60, 55, 50, 45),
+                        new MatchesSummaryByLevel(60, 55, 50, 45)
+                    ),
+                    new RegionSummary(
+                        100,
+                        new MatchesSummaryByLevel(60, 55, 50, 45),
+                        new MatchesSummaryByLevel(60, 55, 50, 45)
+                    )
+                )
+            );
+
+        var response = await client.GetAsync(
+            Testing.Endpoints.Matches.SummaryByLevelByRegion(
+                EndpointQuery.New.Where(EndpointFilter.From(from)).Where(EndpointFilter.To(to))
+            )
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        await VerifyJson(await response.Content.ReadAsStringAsync()).UseStrictJson().DontScrubDateTimes();
+    }
+
+    [Fact]
+    public async Task Get_WhenAuthorized_AndFromAfterTo_ShouldBeBadRequest()
+    {
+        var client = CreateClient();
+
+        var response = await client.GetAsync(
+            Testing.Endpoints.Matches.SummaryByLevelByRegion(
+                EndpointQuery
+                    .New.Where(EndpointFilter.From(DateTime.UtcNow.AddDays(1)))
+                    .Where(EndpointFilter.To(DateTime.UtcNow))
+            )
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        await VerifyJson(await response.Content.ReadAsStringAsync()).UseStrictJson().ScrubMember("traceId");
+    }
+
+    [Fact]
+    public async Task Get_WhenAuthorized_AndDateSpanGreaterThanAllowedDays_ShouldBeBadRequest()
+    {
+        var client = CreateClient();
+
+        var response = await client.GetAsync(
+            Testing.Endpoints.Matches.SummaryByLevelByRegion(
+                EndpointQuery
+                    .New.Where(EndpointFilter.From(DateTime.UtcNow))
+                    .Where(EndpointFilter.To(DateTime.UtcNow.AddDays(TimePeriod.MaxDays + 1)))
+            )
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        await VerifyJson(await response.Content.ReadAsStringAsync()).UseStrictJson().ScrubMember("traceId");
+    }
+
+    [Fact]
+    public async Task Get_WhenAuthorized_AndFromAndToNotUtc_ShouldBeBadRequest()
+    {
+        var client = CreateClient();
+
+        var now = DateTime.SpecifyKind(DateTime.Now, DateTimeKind.Unspecified);
+        var response = await client.GetAsync(
+            Testing.Endpoints.Matches.SummaryByLevelByRegion(
+                EndpointQuery.New.Where(EndpointFilter.From(now)).Where(EndpointFilter.To(now.AddDays(1)))
+            )
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        await VerifyJson(await response.Content.ReadAsStringAsync()).UseStrictJson().ScrubMember("traceId");
+    }
+}

--- a/tests/Api.Tests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
+++ b/tests/Api.Tests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
@@ -512,6 +512,68 @@
         }
       }
     },
+    "/matches/summary/levels-by-region": {
+      "get": {
+        "tags": [
+          "Decisions"
+        ],
+        "summary": "Get matches summary counts by level by group",
+        "description": "Searchable period is the last 122 days",
+        "operationId": "MatchesSummaryByLevelByRegion",
+        "parameters": [
+          {
+            "name": "from",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeclarationSummary"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/clearance-requests/summary": {
       "get": {
         "tags": [
@@ -1572,6 +1634,26 @@
           }
         }
       },
+      "DeclarationSummary": {
+        "required": [
+          "total",
+          "eu",
+          "row"
+        ],
+        "type": "object",
+        "properties": {
+          "total": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "format": "int32"
+          },
+          "eu": {
+            "$ref": "#/components/schemas/RegionSummary"
+          },
+          "row": {
+            "$ref": "#/components/schemas/RegionSummary"
+          }
+        }
+      },
       "IntervalResponseOfClearanceRequestsSummaryResponse": {
         "required": [
           "interval",
@@ -1835,6 +1917,33 @@
           }
         }
       },
+      "MatchesSummaryByLevel": {
+        "required": [
+          "total",
+          "level1",
+          "level2",
+          "level3"
+        ],
+        "type": "object",
+        "properties": {
+          "total": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "format": "int32"
+          },
+          "level1": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "format": "int32"
+          },
+          "level2": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "format": "int32"
+          },
+          "level3": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "format": "int32"
+          }
+        }
+      },
       "MatchesSummaryByLevelResponse": {
         "required": [
           "level1",
@@ -1955,6 +2064,26 @@
           "instance": {
             "type": "string",
             "nullable": true
+          }
+        }
+      },
+      "RegionSummary": {
+        "required": [
+          "total",
+          "match",
+          "noMatch"
+        ],
+        "type": "object",
+        "properties": {
+          "total": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "format": "int32"
+          },
+          "match": {
+            "$ref": "#/components/schemas/MatchesSummaryByLevel"
+          },
+          "noMatch": {
+            "$ref": "#/components/schemas/MatchesSummaryByLevel"
           }
         }
       },

--- a/tests/Testing/Endpoints.cs
+++ b/tests/Testing/Endpoints.cs
@@ -30,6 +30,9 @@ public static class Endpoints
 
         public static string SummaryByLevel(EndpointQuery? query = null) => $"{Root}/summary/levels{query}";
 
+        public static string SummaryByLevelByRegion(EndpointQuery? query = null) =>
+            $"{Root}/summary/levels-by-region{query}";
+
         public static string Intervals(EndpointQuery? query = null) => $"{Root}/intervals{query}";
 
         public static string Data(EndpointQuery? query = null) => $"{Root}/data{query}";


### PR DESCRIPTION


Introduces a new endpoint `/matches/summary/levels-by-region` to provide aggregated customs declaration statistics. The summary includes totals, and breakdowns for EU and Rest of World regions. Within each region, matched and non-matched declarations are further categorized by their Level 1, 2, and 3 match status. This enhances reporting capabilities by providing granular insights into declaration outcomes.

