### PR TITLE
CDMS-1478: Update Defra.TradeImportsDataApi.Domain package

### DIFF
--- a/src/Api/Api.csproj
+++ b/src/Api/Api.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Snappier" Version="1.3.1" />
-    <PackageReference Include="Defra.TradeImportsDataApi.Domain" Version="0.36.0-pr-546.2380" />
+    <PackageReference Include="Defra.TradeImportsDataApi.Domain" Version="0.38.0" />
     <PackageReference Include="Defra.TradeImports.SQS.Endpoints" Version="0.1.2" />
     <PackageReference Include="CsvHelper" Version="33.1.0" />
     <PackageReference Include="Elastic.CommonSchema.Serilog" Version="9.0.0" />

--- a/src/Api/Api.csproj
+++ b/src/Api/Api.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
@@ -16,7 +16,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Snappier" Version="1.3.1" />
-    <PackageReference Include="Defra.TradeImportsDataApi.Domain" Version="0.35.0" />
+    <PackageReference Include="Defra.TradeImportsDataApi.Domain" Version="0.36.0-pr-546.2380" />
     <PackageReference Include="Defra.TradeImports.SQS.Endpoints" Version="0.1.2" />
     <PackageReference Include="CsvHelper" Version="33.1.0" />
     <PackageReference Include="Elastic.CommonSchema.Serilog" Version="9.0.0" />


### PR DESCRIPTION
Bumps the `Defra.TradeImportsDataApi.Domain` package to version `0.36.0-pr-546.2380` in support of ongoing development for CDMS-1478.
